### PR TITLE
Cloud Functionsのメモリーを増やす

### DIFF
--- a/functions/package.json
+++ b/functions/package.json
@@ -4,7 +4,7 @@
   "main": "src/index.js",
   "scripts": {
     "build": "tsc",
-    "deploy": "yarn build;gcloud functions deploy saveCoronaCalendarToGCS --entry-point saveCoronaCalendarToGCS --runtime nodejs12 --trigger-topic saveCoronaCalendarToGCS",
+    "deploy": "yarn build;gcloud functions deploy saveCoronaCalendarToGCS --entry-point saveCoronaCalendarToGCS --runtime nodejs12 --trigger-topic saveCoronaCalendarToGCS --memory=512",
     "test": "jest --watchAll",
     "test:ci": "jest",
     "fix": "run-s fix:eslint fix:prettier",


### PR DESCRIPTION
## 概要
東京の感染者数が異様に増えた結果、
Clound Functionsの実行時メモリーが256MBでは足りなくなったので512MBへ変更。

## 参考
https://cloud.google.com/functions/docs/concepts/exec?hl=ja#memory