### PR TITLE
感染者数ごとのセル色を変える

### DIFF
--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,9 +1,0 @@
-import React from 'react';
-import { render, screen } from '@testing-library/react';
-import App from './App';
-
-test('renders learn react link', () => {
-  render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
-});

--- a/src/components/CoronaWeeklyTable/CoronaWeeklyTable.tsx
+++ b/src/components/CoronaWeeklyTable/CoronaWeeklyTable.tsx
@@ -13,6 +13,7 @@ import {
 import { format } from 'date-fns';
 import React from 'react';
 import { useCorona } from '../../model/useTokyoCorona';
+import { severity } from '../../model/severity';
 
 const useStyles = makeStyles(theme => ({
   root: {
@@ -46,6 +47,10 @@ const useStyles = makeStyles(theme => ({
       },
       '&[data-sd="3"]': {
         backgroundColor: '#EA0000',
+        color: 'white',
+      },
+      '&[data-sd="4"]': {
+        backgroundColor: '#910400',
         color: 'white',
       },
     },
@@ -95,14 +100,16 @@ export const CoronaWeeklyTable = () => {
                   {weekTable[week].map((d, d_i) => (
                     <TableCell
                       key={`${week}-${d_i}`}
-                      data-sd={d.count >= 300 ? 3 : Math.floor(d.count / 100)}
+                      data-sd={severity(d.count)}
                       align="right"
                     >
-                      {(w_i === 0 && d.count) || w_i !== 0 ? d.count : null}
+                      {(w_i === 0 && d.count) || w_i !== 0
+                        ? d.count.toLocaleString()
+                        : null}
                     </TableCell>
                   ))}
                   <TableCell key={`${week}-sum`} align="right">
-                    {weekSumTable[week].count}
+                    {weekSumTable[week].count.toLocaleString()}
                   </TableCell>
                 </TableRow>
               );

--- a/src/model/severity.test.ts
+++ b/src/model/severity.test.ts
@@ -1,0 +1,17 @@
+import { severity } from './severity';
+
+it('感染者数ごとの深刻度が正しいかを確認', () => {
+  // 深刻度は、例えばテーブルのセルの塗りつぶしなどに使用可能。
+  // 深刻度が高いものほど、濃い色で塗りつぶすなど。
+
+  expect(severity(10)).toBe(0);
+  expect(severity(125)).toBe(1);
+  expect(severity(250)).toBe(1);
+  expect(severity(333)).toBe(2);
+  expect(severity(499)).toBe(2);
+  expect(severity(501)).toBe(3);
+  expect(severity(701)).toBe(3);
+  expect(severity(999)).toBe(3);
+  expect(severity(1000)).toBe(4);
+  expect(severity(20000)).toBe(4);
+});

--- a/src/model/severity.ts
+++ b/src/model/severity.ts
@@ -1,0 +1,8 @@
+export const severity = (count: number) => {
+  const c = Math.floor(count / 100);
+  if (c == 0) return 0;
+  if (c <= 2) return 1;
+  if (c <= 4) return 2;
+  if (c <= 9) return 3;
+  return 4;
+};


### PR DESCRIPTION
## 概要
一日あたりの感染者数が1000人を超えるような事態になったため、感染者数毎のセル色を変更。

- 100人以上300人未満 → 薄い黄色
- 500人未満 → 薄い赤色
- 1000人未満 → 濃い赤色
- 1000人以上 → 茶色 

<img width="400" alt="スクリーンショット 2021-02-08 0 46 36" src="https://user-images.githubusercontent.com/7910558/107151671-1ce29b80-69a7-11eb-9a9d-bbd0599139ed.png">
